### PR TITLE
Changed how server_target works. You can specify the consul_server_ta…

### DIFF
--- a/tests/manual/consul_test.py
+++ b/tests/manual/consul_test.py
@@ -1,0 +1,43 @@
+set server_target '*'
+
+verify that /etc/consul.conf contains
+"data_dir": "/opt/consul/data",
+"server": true
+AND
+/etc/salt/grains contains
+consul_server_target_from_pillar: true
+
+set server_target 'noboxmatch'
+verify that /etc/consul.conf contains
+"data_dir": "/opt/consul/data",
+"server": false
+AND
+/etc/salt/grains DOES NOT contain
+consul_server_target_from_pillar: true
+
+set server_target 'noboxmatch' 
+AND
+salt 'boxmatch' grains.setval consul_server_target True
+verify that /etc/consul.conf contains
+"data_dir": "/opt/consul/data",
+"server": true
+AND
+/etc/salt/grains contains
+consul_server_target_from_pillar: true
+
+
+set server_target 'noboxmatch' 
+AND
+salt 'boxmatch' grains.delval consul_server_target destructive=True
+verify that /etc/consul.conf contains
+"data_dir": "/opt/consul/data",
+"server": false
+AND
+/etc/salt/grains DOES NOT contain
+consul_server_target_from_pillar: true
+
+
+
+
+
+


### PR DESCRIPTION
…rget grain as True

or you can just use the server_target pillar which will now set a consul_server_target_from_pillar
grain so that it can be gathered as a grain and set to the salt mine for determining who is a consul
server

Updated the README.md to reflect these changes

Added a manual test doc to describe the options and values based on those options
